### PR TITLE
Bedre håndtering av foreløpig ignorerte deltakelser

### DIFF
--- a/src/main/kotlin/no/nav/arena_tiltak_aktivitet_acl/domain/db/ArenaDataDbo.kt
+++ b/src/main/kotlin/no/nav/arena_tiltak_aktivitet_acl/domain/db/ArenaDataDbo.kt
@@ -8,6 +8,7 @@ import java.time.LocalDateTime
 enum class IngestStatus {
 	NEW,
 	HANDLED,
+	HANDLED_AND_IGNORED,
 	RETRY,
 	FAILED,
 	IGNORED,

--- a/src/main/kotlin/no/nav/arena_tiltak_aktivitet_acl/domain/db/ArenaDataUpsertInput.kt
+++ b/src/main/kotlin/no/nav/arena_tiltak_aktivitet_acl/domain/db/ArenaDataUpsertInput.kt
@@ -46,6 +46,10 @@ fun ArenaKafkaMessage<*>.toUpsertInputWithStatusHandled(arenaId: DeltakelseId, n
 	return this.toUpsertInput(arenaId.value.toString(), IngestStatus.HANDLED, note)
 }
 
+fun ArenaKafkaMessage<*>.toUpsertInputWithStatusHandledAndIgnored(arenaId: DeltakelseId, note: String? = null): ArenaDataUpsertInput {
+	return this.toUpsertInput(arenaId.value.toString(), IngestStatus.HANDLED_AND_IGNORED, note)
+}
+
 fun ArenaKafkaMessage<*>.toUpsertInputWithStatusHandled(arenaId: String): ArenaDataUpsertInput {
 	return this.toUpsertInput(arenaId, IngestStatus.HANDLED, null)
 }

--- a/src/main/kotlin/no/nav/arena_tiltak_aktivitet_acl/domain/kafka/aktivitet/Aktivitetskort.kt
+++ b/src/main/kotlin/no/nav/arena_tiltak_aktivitet_acl/domain/kafka/aktivitet/Aktivitetskort.kt
@@ -43,7 +43,7 @@ data class Aktivitetskort(
 	val detaljer: List<Attributt>
 ) {
 	private val objectMapper = ObjectMapper.get()
-	fun toDbo(headers: AktivitetskortHeaders) = AktivitetDbo(
+	fun toDbo(headers: AktivitetskortHeaders, forelopigIgnorert: Boolean) = AktivitetDbo(
 		id = id,
 		personIdent = personIdent,
 		kategori = AktivitetKategori.TILTAKSAKTIVITET,
@@ -52,6 +52,7 @@ data class Aktivitetskort(
 		tiltakKode = headers.tiltakKode,
 		oppfolgingsperiodeUUID = headers.oppfolgingsperiode,
 		oppfolgingsSluttTidspunkt = headers.oppfolgingsSluttDato,
+		forelopigIgnorert = forelopigIgnorert
 	)
 
 	fun toKafkaMessage() = KafkaMessageDto(

--- a/src/main/kotlin/no/nav/arena_tiltak_aktivitet_acl/processors/DeltakerProcessor.kt
+++ b/src/main/kotlin/no/nav/arena_tiltak_aktivitet_acl/processors/DeltakerProcessor.kt
@@ -124,7 +124,7 @@ open class DeltakerProcessor(
 			oppfolgingsperiode = periodeMatch.oppfolgingsperiode.uuid,
 			oppfolgingsSluttDato = periodeMatch.oppfolgingsperiode.sluttDato
 		)
-		aktivitetService.upsert(aktivitet, aktivitetskortHeaders, deltakelse.tiltakdeltakelseId)
+		aktivitetService.upsert(aktivitet, aktivitetskortHeaders, deltakelse.tiltakdeltakelseId, endring.skalIgnoreres)
 
 		if (endring.skalIgnoreres) {
 			log.info("Deltakeren har status=${arenaDeltaker.DELTAKERSTATUSKODE} og administrasjonskode=${tiltak.administrasjonskode} som ikke skal håndteres")

--- a/src/main/kotlin/no/nav/arena_tiltak_aktivitet_acl/processors/DeltakerProcessor.kt
+++ b/src/main/kotlin/no/nav/arena_tiltak_aktivitet_acl/processors/DeltakerProcessor.kt
@@ -76,13 +76,6 @@ open class DeltakerProcessor(
 		val tiltak = tiltakService.getByKode(gjennomforing.tiltakKode)
 			?: throw DependencyNotIngestedException("Venter på at tiltak med id=${gjennomforing.tiltakKode} skal bli håndtert")
 
-
-		if (message.operationType == Operation.DELETED && deltakelse.erAvsluttet()) {
-			log.info("Mottok slettemelding men deltaker var allerede i en ferdig-status")
-			arenaDataRepository.upsert(message.toUpsertInputWithStatusHandledAndIgnored(deltakelse.tiltakdeltakelseId, "ignorert slettemelding"))
-			return
-		}
-
 		val personIdent = personsporingService.get(deltakelse.personId, arenaGjennomforingId).fodselsnummer
 
 		/*
@@ -93,7 +86,7 @@ open class DeltakerProcessor(
 			if (deltakelse.opprettetFørMenAktivEtterLansering()) {
 				getOppfolgingsperiodeForPersonVedLansering(personIdent)
 			} else getOppfolgingsPeriodeOrThrow(deltakelse, personIdent)
-		val endring = utledEndringsType(periodeMatch, deltakelse.tiltakdeltakelseId, arenaDeltaker.DELTAKERSTATUSKODE, tiltak.administrasjonskode, message.operationTimestamp)
+		val endring = utledEndringsType(periodeMatch, deltakelse.tiltakdeltakelseId, arenaDeltaker.DELTAKERSTATUSKODE, tiltak.administrasjonskode, message.operationTimestamp, message.operationType)
 		when (endring) {
 			is EndringsType.NyttAktivitetskortByttPeriode  -> {
 				secureLog.info("Endring på deltakelse ${deltakelse.tiltakdeltakelseId} på deltakerId ${deltakelse.tiltakdeltakelseId} til ny aktivitetsid ${endring.aktivitetskortId} og oppfølgingsperiode ${periodeMatch.oppfolgingsperiode.uuid}. " +
@@ -125,9 +118,16 @@ open class DeltakerProcessor(
 			oppfolgingsperiode = periodeMatch.oppfolgingsperiode.uuid,
 			oppfolgingsSluttDato = periodeMatch.oppfolgingsperiode.sluttDato
 		)
-		aktivitetService.upsert(aktivitet, aktivitetskortHeaders, deltakelse.tiltakdeltakelseId, endring.skalIgnoreres)
 
-		if (endring.skalIgnoreres) {
+		aktivitetService.upsert(aktivitet, aktivitetskortHeaders, deltakelse.tiltakdeltakelseId, IgnorertStatus.IKKE_IGNORERT != endring.skalIgnoreres )
+
+		if (endring.skalIgnoreres == IgnorertStatus.IGNORERT_SLETTEMELDING) {
+			log.info("Mottok slettemelding men deltaker var allerede i en ferdig-status")
+			arenaDataRepository.upsert(message.toUpsertInputWithStatusHandledAndIgnored(deltakelse.tiltakdeltakelseId, "ignorert slettemelding"))
+			return
+		}
+
+		if (endring.skalIgnoreres == IgnorertStatus.FORELOPIG_IGNORERT) {
 			log.info("Deltakeren har status=${arenaDeltaker.DELTAKERSTATUSKODE} og administrasjonskode=${tiltak.administrasjonskode} som ikke skal håndteres")
 			arenaDataRepository.upsert(message.toUpsertInputWithStatusHandledAndIgnored(deltakelse.tiltakdeltakelseId, "foreløpig ignorert"))
 			return
@@ -146,11 +146,14 @@ open class DeltakerProcessor(
 
 	//	Alle tiltaksaktiviteter hentes med unntak for tiltak av
 	//	administrasjonstypene Institusjonelt tiltak (INST) og Individuelt tiltak (IND) som har deltakerstatus Aktuell (AKTUELL).
-	private fun skalIgnoreres(arenaDeltakerStatusKode: String, administrasjonskode: Tiltak.Administrasjonskode, deltakelseId: DeltakelseId, operationTimestamp: LocalDateTime): Boolean {
+	private fun skalIgnoreres(arenaDeltakerStatusKode: String, administrasjonskode: Tiltak.Administrasjonskode, deltakelseId: DeltakelseId, operationTimestamp: LocalDateTime, operationType: Operation): IgnorertStatus {
 		// hvis vi har en tidligere endring som har gått gjennom til aktivitetsplan, kan vi ikke ignorere disse endringene.
-		if (arenaDataRepository.harTidligereEndringSomIkkeErIgnorert(deltakelseId, operationTimestamp)) return false
-		else return arenaDeltakerStatusKode == "AKTUELL"
-			&& administrasjonskode in listOf(Tiltak.Administrasjonskode.IND, Tiltak.Administrasjonskode.INST)
+		if (arenaDataRepository.harTidligereEndringSomIkkeErIgnorert(deltakelseId, operationTimestamp)) return IgnorertStatus.IKKE_IGNORERT
+		else if (arenaDeltakerStatusKode == "AKTUELL"
+			&& administrasjonskode in listOf(Tiltak.Administrasjonskode.IND, Tiltak.Administrasjonskode.INST)) return IgnorertStatus.FORELOPIG_IGNORERT
+		else if (operationType == Operation.DELETED && ArenaDeltakerConverter.toAktivitetStatus(arenaDeltakerStatusKode).erAvsluttet()) return IgnorertStatus.IGNORERT_SLETTEMELDING
+		else return IgnorertStatus.IKKE_IGNORERT
+
 	}
 
 	private fun handleOppfolgingsperiodeNull(deltakelse: TiltakDeltakelse, personIdent: String, tidspunkt: LocalDateTime, tiltakDeltakelseId: DeltakelseId): Nothing {
@@ -188,9 +191,10 @@ open class DeltakerProcessor(
 		deltakelseId: DeltakelseId,
 		deltakerStatusKode: String,
 		administrasjonskode: Tiltak.Administrasjonskode,
-		operationTimestamp: LocalDateTime
+		operationTimestamp: LocalDateTime,
+		operationType: Operation
 	): EndringsType {
-		val skalIgnoreres = skalIgnoreres(deltakerStatusKode, administrasjonskode, deltakelseId, operationTimestamp)
+		val skalIgnoreres = skalIgnoreres(deltakerStatusKode, administrasjonskode, deltakelseId, operationTimestamp, operationType)
 		val oppfolgingsperiodeTilAktivitetskortId = aktivitetService.getAllBy(deltakelseId, AktivitetKategori.TILTAKSAKTIVITET)
 		val eksisterendeAktivitetsId = oppfolgingsperiodeTilAktivitetskortId
 			.firstOrNull { it.oppfolgingsPeriode == periodeMatch.oppfolgingsperiode.uuid }?.id
@@ -239,10 +243,16 @@ open class DeltakerProcessor(
 	}
 }
 
-sealed class EndringsType(val aktivitetskortId: UUID, val skalIgnoreres: Boolean) {
-	class OppdaterAktivitet(aktivitetskortId: UUID, skalIgnoreres: Boolean): EndringsType(aktivitetskortId, skalIgnoreres)
-	class NyttAktivitetskort(aktivitetskortId:UUID, val oppfolgingsperiode: Oppfolgingsperiode, skalIgnoreres: Boolean): EndringsType(aktivitetskortId, skalIgnoreres)
-	class NyttAktivitetskortByttPeriode(val oppfolgingsperiode: Oppfolgingsperiode, skalIgnoreres: Boolean): EndringsType(UUID.randomUUID(), skalIgnoreres)
+enum class IgnorertStatus {
+	FORELOPIG_IGNORERT,
+	IGNORERT_SLETTEMELDING,
+	IKKE_IGNORERT
+}
+
+sealed class EndringsType(val aktivitetskortId: UUID, val skalIgnoreres: IgnorertStatus) {
+	class OppdaterAktivitet(aktivitetskortId: UUID, skalIgnoreres: IgnorertStatus): EndringsType(aktivitetskortId, skalIgnoreres)
+	class NyttAktivitetskort(aktivitetskortId:UUID, val oppfolgingsperiode: Oppfolgingsperiode, skalIgnoreres: IgnorertStatus): EndringsType(aktivitetskortId, skalIgnoreres)
+	class NyttAktivitetskortByttPeriode(val oppfolgingsperiode: Oppfolgingsperiode, skalIgnoreres: IgnorertStatus): EndringsType(UUID.randomUUID(), skalIgnoreres)
 }
 
 

--- a/src/main/kotlin/no/nav/arena_tiltak_aktivitet_acl/repositories/AktivitetDbo.kt
+++ b/src/main/kotlin/no/nav/arena_tiltak_aktivitet_acl/repositories/AktivitetDbo.kt
@@ -13,5 +13,6 @@ data class AktivitetDbo (
 	val tiltakKode: String,
 	val oppfolgingsperiodeUUID: UUID,
 	val oppfolgingsSluttTidspunkt: ZonedDateTime?,
+	val forelopigIgnorert: Boolean = false
 ) {
 }

--- a/src/main/kotlin/no/nav/arena_tiltak_aktivitet_acl/repositories/AktivitetRepository.kt
+++ b/src/main/kotlin/no/nav/arena_tiltak_aktivitet_acl/repositories/AktivitetRepository.kt
@@ -23,7 +23,7 @@ class AktivitetRepository(
 	fun upsert(aktivitet: AktivitetDbo) {
 		@Language("PostgreSQL")
 		val sql = """
-			INSERT INTO aktivitet(id, person_ident, kategori_type, data, arena_id, tiltak_kode, oppfolgingsperiode_uuid, oppfolgingsperiode_slutt_tidspunkt)
+			INSERT INTO aktivitet(id, person_ident, kategori_type, data, arena_id, tiltak_kode, oppfolgingsperiode_uuid, oppfolgingsperiode_slutt_tidspunkt, forelopig_ignorert)
 			VALUES (:id,
 					:person_ident,
 					:kategori_type,
@@ -31,11 +31,13 @@ class AktivitetRepository(
 					:arena_id,
 					:tiltak_kode,
 					:oppfolgingsperiode_uuid,
-					:oppfolgingsperiode_slutt_tidspunkt)
+					:oppfolgingsperiode_slutt_tidspunkt,
+					:forelopig_ignorert)
 			ON CONFLICT ON CONSTRAINT aktivitet_pkey
 			DO UPDATE SET data = :data::jsonb,
 				oppfolgingsperiode_slutt_tidspunkt = :oppfolgingsperiode_slutt_tidspunkt,
-				oppfolgingsperiode_uuid = :oppfolgingsperiode_uuid
+				oppfolgingsperiode_uuid = :oppfolgingsperiode_uuid,
+				forelopig_ignorert = :forelopig_ignorert
 		""".trimIndent()
 
 		val parameters = MapSqlParameterSource().addValues(
@@ -48,6 +50,7 @@ class AktivitetRepository(
 				"tiltak_kode" to aktivitet.tiltakKode,
 				"oppfolgingsperiode_uuid" to aktivitet.oppfolgingsperiodeUUID,
 				"oppfolgingsperiode_slutt_tidspunkt" to aktivitet.oppfolgingsSluttTidspunkt?.toOffsetDateTime(),
+				"forelopig_ignorert" to aktivitet.forelopigIgnorert
 			)
 		)
 

--- a/src/main/kotlin/no/nav/arena_tiltak_aktivitet_acl/repositories/ArenaDataRepository.kt
+++ b/src/main/kotlin/no/nav/arena_tiltak_aktivitet_acl/repositories/ArenaDataRepository.kt
@@ -164,7 +164,7 @@ open class ArenaDataRepository(
 	fun getByIngestStatus(
 		tableName: ArenaTableName,
 		status: IngestStatus,
-		fromPos: OperationPos,
+		fromTimestamp: LocalDateTime,
 		limit: Int = 500
 	): List<ArenaDataDbo> {
 		//language=PostgreSQL
@@ -173,7 +173,7 @@ open class ArenaDataRepository(
 			FROM arena_data
 			WHERE ingest_status = :ingestStatus
 			AND arena_table_name = :tableName
-			AND operation_pos > :fromPos
+			AND operation_timestamp > :fromTs
 			ORDER BY operation_pos ASC
 			LIMIT :limit
 		""".trimIndent()
@@ -181,7 +181,7 @@ open class ArenaDataRepository(
 		val parameters = sqlParameters(
 			"ingestStatus" to status.name,
 			"tableName" to tableName.tableName,
-			"fromPos" to fromPos.value,
+			"fromTs" to fromTimestamp,
 			"limit" to limit
 		)
 		val resultat = template.query(sql, parameters, arenaDataRowMapper)

--- a/src/main/kotlin/no/nav/arena_tiltak_aktivitet_acl/services/AktivitetService.kt
+++ b/src/main/kotlin/no/nav/arena_tiltak_aktivitet_acl/services/AktivitetService.kt
@@ -26,9 +26,9 @@ open class AktivitetService(
 	 * @see no.nav.arena_tiltak_aktivitet_acl.services.AktivitetskortIdService.getOrCreate
 	 */
 	@Transactional(propagation = Propagation.MANDATORY)
-	open fun upsert(aktivitet: Aktivitetskort, headers: AktivitetskortHeaders, deltakelseId: DeltakelseId) {
+	open fun upsert(aktivitet: Aktivitetskort, headers: AktivitetskortHeaders, deltakelseId: DeltakelseId, forelopigIgnorert: Boolean = false) {
 		deltakerLockRepository.safeDeltakelse(deltakelseId).use {
-			aktivitetRepository.upsert(aktivitet.toDbo(headers))
+			aktivitetRepository.upsert(aktivitet.toDbo(headers, forelopigIgnorert))
 			aktivitetskortIdRepository.deleteDeltakelseId(deltakelseId, AktivitetKategori.TILTAKSAKTIVITET)
 		}
 	}

--- a/src/main/resources/db/migration/V22__aktivitet_forelopig_ignorert.sql
+++ b/src/main/resources/db/migration/V22__aktivitet_forelopig_ignorert.sql
@@ -1,0 +1,1 @@
+alter table aktivitet add column forelopig_ignorert boolean default false;

--- a/src/main/resources/db/migration/V23__utvide_ingest_status_check.sql
+++ b/src/main/resources/db/migration/V23__utvide_ingest_status_check.sql
@@ -2,6 +2,7 @@
  Husk
  update arena_data set ingest_status = 'HANDLED_AND_IGNORED'
     where ingest_status = 'HANDLED' and note in ('ignorert slettemelding','foreløpig ignorert')
+ Eller helst sette til 'QUEUED' og la acl oppdatere, dersom mulig
  */
 ALTER TABLE arena_data DROP CONSTRAINT "arena_data_ingest_status_check";
 AlTER TABLE arena_data ADD CONSTRAINT "arena_data_ingest_status_check"

--- a/src/main/resources/db/migration/V23__utvide_ingest_status_check.sql
+++ b/src/main/resources/db/migration/V23__utvide_ingest_status_check.sql
@@ -1,0 +1,8 @@
+/*
+ Husk
+ update arena_data set ingest_status = 'HANDLED_AND_IGNORED'
+    where ingest_status = 'HANDLED' and note in ('ignorert slettemelding','foreløpig ignorert')
+ */
+ALTER TABLE arena_data DROP CONSTRAINT "arena_data_ingest_status_check";
+AlTER TABLE arena_data ADD CONSTRAINT "arena_data_ingest_status_check"
+    CHECK ( ingest_status in ('NEW', 'HANDLED', 'HANDLED_AND_IGNORED', 'RETRY', 'FAILED', 'IGNORED', 'INVALID', 'QUEUED') );

--- a/src/main/resources/db/migration/V24__arena_data_operation_ts_index.sql
+++ b/src/main/resources/db/migration/V24__arena_data_operation_ts_index.sql
@@ -1,0 +1,2 @@
+create index if not exists arena_data_operation_timestamp_index
+    on arena_data (operation_timestamp);

--- a/src/test/kotlin/no/nav/arena_tiltak_aktivitet_acl/integration/DeltakerIntegrationTests.kt
+++ b/src/test/kotlin/no/nav/arena_tiltak_aktivitet_acl/integration/DeltakerIntegrationTests.kt
@@ -846,9 +846,8 @@ class DeltakerIntegrationTests : IntegrationTestBase() {
 			deltakerStatusKode = "AKTUELL",
 		)
 		val deltakerCommandIgnored = NyDeltakerCommand(deltakerInputIgnored)
-		val aktivitetResultIgnored = deltakerExecutor.execute(deltakerCommandIgnored, expectAktivitetskortOnTopic = false)
-		aktivitetResultIgnored.arenaDataDbo.ingestStatus shouldBe IngestStatus.HANDLED
-		aktivitetResultIgnored.arenaDataDbo.note shouldBe "foreløpig ignorert"
+		val aktivitetResultIgnored = deltakerExecutor.execute(deltakerCommandIgnored)
+		aktivitetResultIgnored.arenaDataDbo.ingestStatus shouldBe IngestStatus.HANDLED_AND_IGNORED
 
 		idMappingClient.hentMapping(TranslationQuery(deltakelseId.value, AktivitetKategori.TILTAKSAKTIVITET)) shouldNotBe null
 
@@ -872,9 +871,8 @@ class DeltakerIntegrationTests : IntegrationTestBase() {
 			deltakerStatusKode = "AKTUELL",
 		)
 		val deltakerCommandIgnored = NyDeltakerCommand(deltakerInputIgnored)
-		deltakerExecutor.execute(deltakerCommandIgnored, expectAktivitetskortOnTopic = false)
-			.expectHandledAndIngored { result ->
-				result.arenaDataDbo.note shouldBe "foreløpig ignorert" }
+		deltakerExecutor.execute(deltakerCommandIgnored)
+			.expectHandledAndIngored { result -> result.arenaDataDbo.note shouldBe "foreløpig ignorert"}
 
 
 		idMappingClient.hentMapping(TranslationQuery(deltakelseId.value, AktivitetKategori.TILTAKSAKTIVITET)) shouldNotBe null
@@ -905,16 +903,14 @@ class DeltakerIntegrationTests : IntegrationTestBase() {
 			deltakerStatusKode = "AKTUELL",
 		)
 		val deltakerCommandIgnored = NyDeltakerCommand(deltakerInputIgnored)
-		deltakerExecutor.execute(deltakerCommandIgnored, expectAktivitetskortOnTopic = false)
-			.expectHandledAndIngored {
-				result -> result.arenaDataDbo.note shouldBe "foreløpig ignorert"
-			}
+		deltakerExecutor.execute(deltakerCommandIgnored)
+			.expectHandledAndIngored { result -> result.arenaDataDbo.note shouldBe "foreløpig ignorert" }
 
 		idMappingClient.hentMapping(TranslationQuery(deltakelseId.value, AktivitetKategori.TILTAKSAKTIVITET)) shouldNotBe null
 
 		val deltakerInputFremdelesIgnorert = deltakerInputIgnored.copy(datoTil = LocalDate.now())
 		val deltakerCommandFremdelesIgnorert = OppdaterDeltakerCommand(deltakerInputIgnored, deltakerInputFremdelesIgnorert)
-		deltakerExecutor.execute(deltakerCommandFremdelesIgnorert, expectAktivitetskortOnTopic = false)
+		deltakerExecutor.execute(deltakerCommandFremdelesIgnorert)
 			.expectHandledAndIngored { result -> result.arenaDataDbo.note shouldBe "foreløpig ignorert" }
 
 	}
@@ -1092,7 +1088,9 @@ class DeltakerIntegrationTests : IntegrationTestBase() {
 			arenaData.output.aktivitetskort.aktivitetStatus shouldBe AktivitetStatus.FULLFORT
 		}
 		val slettetDeltakerCommand = SletteDeltakerCommand(deltakerInput)
-		deltakerExecutor.execute(slettetDeltakerCommand, expectAktivitetskortOnTopic = false).expectHandledAndIngored {}
+		deltakerExecutor.execute(slettetDeltakerCommand).expectHandledAndIngored {
+			result -> result.arenaDataDbo.note shouldBe "ignorert slettemelding"
+		}
 	}
 
 	@Test
@@ -1106,7 +1104,9 @@ class DeltakerIntegrationTests : IntegrationTestBase() {
 			deltakerStatusKode = "FULLF"
 		)
 		val slettetDeltakerCommand = SletteDeltakerCommand(deltakerInput)
-		deltakerExecutor.execute(slettetDeltakerCommand, expectAktivitetskortOnTopic = false).expectHandledAndIngored {}
+		deltakerExecutor.execute(slettetDeltakerCommand).expectHandledAndIngored {
+			result -> result.arenaDataDbo.note shouldBe "ignorert slettemelding"
+		}
 	}
 
 	private val idMappingClient: IdMappingClient by lazy {

--- a/src/test/kotlin/no/nav/arena_tiltak_aktivitet_acl/integration/DeltakerIntegrationTests.kt
+++ b/src/test/kotlin/no/nav/arena_tiltak_aktivitet_acl/integration/DeltakerIntegrationTests.kt
@@ -846,18 +846,13 @@ class DeltakerIntegrationTests : IntegrationTestBase() {
 			deltakerStatusKode = "AKTUELL",
 		)
 		val deltakerCommandIgnored = NyDeltakerCommand(deltakerInputIgnored)
-		val aktivitetResultIgnored = deltakerExecutor.execute(deltakerCommandIgnored)
-		aktivitetResultIgnored.arenaDataDbo.ingestStatus shouldBe IngestStatus.HANDLED_AND_IGNORED
+		deltakerExecutor.execute(deltakerCommandIgnored).expectHandledAndIngored { result -> result.arenaDataDbo.note shouldBe "foreløpig ignorert" }
 
 		idMappingClient.hentMapping(TranslationQuery(deltakelseId.value, AktivitetKategori.TILTAKSAKTIVITET)) shouldNotBe null
 
 		val deltakerInput = deltakerInputIgnored.copy(deltakerStatusKode = "GJENN")
 		val deltakerCommand = OppdaterDeltakerCommand(deltakerInputIgnored, deltakerInput)
-		val aktivitetResult = deltakerExecutor.execute(deltakerCommand)
-
-		aktivitetResult.expectHandled { result ->
-			result.output.actionType shouldBe ActionType.UPSERT_AKTIVITETSKORT_V1
-		}
+		deltakerExecutor.execute(deltakerCommand).expectHandled { result -> result.output.actionType shouldBe ActionType.UPSERT_AKTIVITETSKORT_V1 }
 	}
 
 	@Test

--- a/src/test/kotlin/no/nav/arena_tiltak_aktivitet_acl/integration/commands/deltaker/AktivitetResult.kt
+++ b/src/test/kotlin/no/nav/arena_tiltak_aktivitet_acl/integration/commands/deltaker/AktivitetResult.kt
@@ -42,7 +42,7 @@ open class AktivitetResult(
 	}
 
 	fun expectHandledAndIngored(check: (data: HandledAndIgnored) -> Unit) {
-		if (this !is HandledAndIgnored) fail("Expected arena message to have ingest status HANDLED and to be ignored but was ${this.arenaDataDbo.ingestStatus}")
+		if (this !is HandledAndIgnored) fail("Expected arena message to have ingest status HandledAndIgnored and to be ignored but was ${this.arenaDataDbo.ingestStatus}")
 		check(this)
 	}
 	fun arenaData(check: (data: ArenaDataDbo) -> Unit): AktivitetResult {

--- a/src/test/kotlin/no/nav/arena_tiltak_aktivitet_acl/repositories/ArenaDataRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/arena_tiltak_aktivitet_acl/repositories/ArenaDataRepositoryTest.kt
@@ -81,7 +81,7 @@ class ArenaDataRepositoryTest : FunSpec({
 		repository.upsert(data)
 		repository.alreadyProcessed(data.arenaId, data.arenaTableName,stringToJsonNode(gammelBefore), stringToJsonNode(gammelAfter)) shouldBe true
 		repository.alreadyProcessed(data.arenaId, data.arenaTableName, stringToJsonNode(nyBefore), stringToJsonNode(nyAfter)) shouldBe false
-		repository.upsert(data.copy(before = nyBefore, after = nyAfter, operationPosition = OperationPos(Random.nextLong(10000))))
+		repository.upsert(data.copy(before = nyBefore, after = nyAfter, operationPosition = OperationPos(Random.nextLong(10000)), operationTimestamp = LocalDateTime.now()))
 		repository.alreadyProcessed(data.arenaId, data.arenaTableName, stringToJsonNode(nyBefore), stringToJsonNode(nyAfter)) shouldBe true
 		repository.alreadyProcessed(data.arenaId, data.arenaTableName, stringToJsonNode(gammelBefore), stringToJsonNode(gammelAfter)) shouldBe false
 	}
@@ -103,7 +103,7 @@ class ArenaDataRepositoryTest : FunSpec({
 		repository.upsert(data)
 		repository.alreadyProcessed(data.arenaId, data.arenaTableName,stringToJsonNode(gammelBefore), stringToJsonNode(gammelAfter)) shouldBe true
 		repository.alreadyProcessed(data.arenaId, data.arenaTableName, stringToJsonNode(nyBefore), stringToJsonNode(nyAfter)) shouldBe false
-		repository.upsert(data.copy(before = nyBefore, after = nyAfter, operationPosition = OperationPos(Random.nextLong(10000))))
+		repository.upsert(data.copy(before = nyBefore, after = nyAfter, operationPosition = OperationPos(Random.nextLong(10000)), operationTimestamp = LocalDateTime.now()))
 		repository.alreadyProcessed(data.arenaId, data.arenaTableName, stringToJsonNode(nyBefore), stringToJsonNode(nyAfter)) shouldBe true
 		repository.alreadyProcessed(data.arenaId, data.arenaTableName, stringToJsonNode(gammelBefore), stringToJsonNode(gammelAfter)) shouldBe false
 	}


### PR DESCRIPTION
- Lagre alle ignorerte deltakelser i `aktivitet` med flagg om den siste meldingen var ignorert
- Ikke ignorere meldinger som har endringer som ikke var ignorert selvom den nye endringen har status AKTUELL og administrasjonskode INST eller IND