### PR TITLE
feat. tiltaksgjennomforing-api inbound med ingress

### DIFF
--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -43,6 +43,9 @@ spec:
         - application: amt-aktivitetskort-publisher
           namespace: amt
           cluster: dev-gcp
+        - application: tiltaksgjennomforing-api
+          namespace: arbeidsgiver
+          cluster: dev-fss
     outbound:
       rules:
         - application: amt-enhetsregister

--- a/.nais/nais-prod.yaml
+++ b/.nais/nais-prod.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   image: ghcr.io/navikt/aktivitet-arena-acl/aktivitet-arena-acl:{{version}}
   port: 8080
+  ingresses:
+    - https://aktivitet-arena-acl.intern.nav.no
   prometheus:
     enabled: true
     path: /internal/prometheus
@@ -41,6 +43,9 @@ spec:
         - application: amt-aktivitetskort-publisher
           namespace: amt
           cluster: prod-gcp
+        - application: tiltaksgjennomforing-api
+          namespace: arbeidsgiver
+          cluster: prod-fss
     outbound:
       rules:
         - application: amt-enhetsregister


### PR DESCRIPTION
Tiltaksgjennomføring-api har behov for å kalle /api/translation/arenaid for å veksle inn deltaker-id fra arena i aktivitetsplan-id.

La til tiltkasgjennomfori-api i inbound for dev og prod. Satt ingress for prod - tiltaksgjennomforing kaller fra fss og kan derfor ikke bruke service-discovery.